### PR TITLE
fix interface in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This logger package
             Info(msg string, args ...interface{})
             Warn(msg string, args ...interface{})
             Error(msg string, args ...interface{}) error
-            Fatal(msg string, args ...interface{}) error
+            Fatal(msg string, args ...interface{})
             Log(level int, msg string, args []interface{})
 
             SetLevel(int)


### PR DESCRIPTION
readme shows Fatal level having an `error` return value, code doesn't