### PR TITLE
Add LTSVFormatter

### DIFF
--- a/v1/formatter.go
+++ b/v1/formatter.go
@@ -45,6 +45,8 @@ func formatFactory(name string, kind string) (Formatter, error) {
 		formatter = NewTextFormatter(name)
 	case FormatJSON:
 		formatter = NewJSONFormatter(name)
+	case FormatLTSV:
+		formatter = NewLTSVFormatter(name)
 	}
 	return formatter, err
 }

--- a/v1/init.go
+++ b/v1/init.go
@@ -161,6 +161,7 @@ func init() {
 	RegisterFormatFactory(FormatHappy, formatFactory)
 	RegisterFormatFactory(FormatText, formatFactory)
 	RegisterFormatFactory(FormatJSON, formatFactory)
+	RegisterFormatFactory(FormatLTSV, formatFactory)
 	ProcessEnv(readFromEnviron())
 
 	// package logger for users

--- a/v1/logger.go
+++ b/v1/logger.go
@@ -100,6 +100,8 @@ const FormatText = "text"
 // FormatJSON uses JSONFormatter
 const FormatJSON = "JSON"
 
+const FormatLTSV = "LTSV"
+
 // FormatEnv selects formatter based on LOGXI_FORMAT environment variable
 const FormatEnv = ""
 

--- a/v1/ltsvFormatter.go
+++ b/v1/ltsvFormatter.go
@@ -1,0 +1,94 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"runtime/debug"
+	"strconv"
+	"time"
+)
+
+var LTSVSeparator = "\t"
+
+type LTSVFormatter struct {
+	name         string
+	itoaLevelMap map[int]string
+}
+
+func NewLTSVFormatter(name string) *LTSVFormatter {
+	var buildKV = func(level string) string {
+		buf := pool.Get()
+		defer pool.Put(buf)
+		buf.WriteString("name:")
+		buf.WriteString(name)
+
+		buf.WriteString(LTSVSeparator)
+		buf.WriteString("level:")
+		buf.WriteString(level)
+
+		buf.WriteString(LTSVSeparator)
+		buf.WriteString("message:")
+
+		return buf.String()
+	}
+
+	itoaLevelMap := map[int]string{
+		LevelDebug: buildKV(LevelMap[LevelDebug]),
+		LevelWarn:  buildKV(LevelMap[LevelWarn]),
+		LevelInfo:  buildKV(LevelMap[LevelInfo]),
+		LevelError: buildKV(LevelMap[LevelError]),
+		LevelFatal: buildKV(LevelMap[LevelFatal]),
+	}
+
+	return &LTSVFormatter{itoaLevelMap: itoaLevelMap, name: name}
+}
+
+func (lf *LTSVFormatter) set(buf bufferWriter, key string, val interface{}) {
+	buf.WriteString(LTSVSeparator)
+	buf.WriteString(key)
+	buf.WriteRune(':')
+	if err, ok := val.(error); ok {
+		buf.WriteString(err.Error())
+		buf.WriteString(LTSVSeparator)
+
+		buf.WriteString(CallStackKey)
+		buf.WriteString(":")
+		buf.WriteString(strconv.Quote(string(debug.Stack())))
+
+		return
+	}
+	buf.WriteString(fmt.Sprintf("%v", val))
+}
+
+func (lf *LTSVFormatter) Format(writer io.Writer, level int, msg string, args []interface{}) {
+	buf := pool.Get()
+	defer pool.Put(buf)
+	buf.WriteString("time:")
+	buf.WriteString(time.Now().Format(timeFormat))
+	buf.WriteString(lf.itoaLevelMap[level])
+	buf.WriteString(msg)
+	var lenArgs = len(args)
+	if lenArgs > 0 {
+		if lenArgs == 1 {
+			lf.set(buf, singleArgKey, args[0])
+		} else if lenArgs%2 == 0 {
+			for i := 0; i < lenArgs; i += 2 {
+				if key, ok := args[i].(string); ok {
+					if key == "" {
+						// show key is invalid
+						lf.set(buf, badKeyAtIndex(i), args[i+1])
+					} else {
+						lf.set(buf, key, args[i+1])
+					}
+				} else {
+					// show key is invalid
+					lf.set(buf, badKeyAtIndex(i), args[i+1])
+				}
+			}
+		} else {
+			lf.set(buf, warnImbalancedKey, args)
+		}
+	}
+	buf.WriteRune('\n')
+	buf.WriteTo(writer)
+}

--- a/v1/ltsvFormatter.go
+++ b/v1/ltsvFormatter.go
@@ -19,6 +19,8 @@ func NewLTSVFormatter(name string) *LTSVFormatter {
 	var buildKV = func(level string) string {
 		buf := pool.Get()
 		defer pool.Put(buf)
+
+		buf.WriteString(LTSVSeparator)
 		buf.WriteString("name:")
 		buf.WriteString(name)
 


### PR DESCRIPTION
I like to use logxi. Sometimes I want to [LTSV](http://ltsv.org/) log for parsing and collectioning. 
What I use / develop an system is still used to LTSV. 

```
$ export LOGXI_FORMAT="LTSV"
$ go run main.go
time:16:14:42.721886	name:test	level:INF	message:Process	pid:15968
time:16:14:42.722039	name:test	level:ERR	message:Process	pid:15968	err:EOF	_c:"/home/msshin/go/logxi/src/github.com/mgutz/logxi/v1/ltsvFormatter.go:58 (0x4434cf)\n\t(*LTSVFormatter).set: buf.WriteString(strconv.Quote(string(debug.Stack())))\n/home/msshin/go/logxi/src/github.com/mgutz/logxi/v1/ltsvFormatter.go:83 (0x443b3f)\n\t(*LTSVFormatter).Format: lf.set(buf, key, args[i+1])\n/home/msshin/go/logxi/src/github.com/mgutz/logxi/v1/defaultLogger.go:104 (0x43b100)\n\t(*DefaultLogger).Log: l.formatter.Format(l.writer, level, msg, args)\n/home/msshin/go/logxi/src/github.com/mgutz/logxi/v1/defaultLogger.go:84 (0x43aeb3)\n\t(*DefaultLogger).extractLogError: return fmt.Errorf(msg)\n/home/msshin/go/logxi/src/github.com/mgutz/logxi/v1/defaultLogger.go:89 (0x43af5b)\n\t(*DefaultLogger).Error: return l.extractLogError(LevelError, msg, args)\n/home/msshin/go/logxi/src/tmp/main.go:13 (0x400fea)\n\tmain: logger.Error(\"Process\", \"pid\", os.Getpid(), \"err\", io.EOF)\n/usr/local/go/src/runtime/proc.go:63 (0x411f43)\n/usr/local/go/src/runtime/asm_amd64.s:2232 (0x421c31)\n"
```
