### PR TITLE
JSONFormatter.appendValue(): check for error first

### DIFF
--- a/v1/jsonFormatter.go
+++ b/v1/jsonFormatter.go
@@ -55,6 +55,13 @@ func (jf *JSONFormatter) appendValue(buf bufferWriter, val interface{}) {
 		return
 	}
 
+	// always show error stack even at cost of some performance. there's
+	// nothing worse than looking at production logs without a clue
+	if err, ok := val.(error); ok {
+		jf.writeError(buf, err)
+		return
+	}
+
 	value := reflect.ValueOf(val)
 	kind := value.Kind()
 	if kind == reflect.Ptr {
@@ -86,14 +93,6 @@ func (jf *JSONFormatter) appendValue(buf bufferWriter, val interface{}) {
 
 	default:
 		var err error
-
-		// always show error stack even at cost of some performance. there's
-		// nothing worse than looking at production logs without a clue
-		if err, ok := val.(error); ok {
-			jf.writeError(buf, err)
-			return
-		}
-
 		var b []byte
 		if stringer, ok := val.(fmt.Stringer); ok {
 			b, err = json.Marshal(stringer.String())


### PR DESCRIPTION
Sometimes, error codes are wrapped in errors with the code like:
```go
type MyError int

func (err MyError) Error() string {
        ...
}
```

[Here](https://github.com/Shopify/sarama/blob/master/errors.go#L70) is an example.

To print proper `.Error()` messages for such types, we have to check for `.(error)` before we do `switch kind`.