### PR TITLE
Use stderr output for benchmark test

### DIFF
--- a/v1/bench/bench_test.go
+++ b/v1/bench/bench_test.go
@@ -36,7 +36,7 @@ func toJSON(m map[string]interface{}) string {
 
 func BenchmarkLog(b *testing.B) {
 	//fmt.Println("")
-	l := L.New(os.Stdout, "bench ", L.LstdFlags)
+	l := L.New(os.Stderr, "bench ", L.LstdFlags)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		debug := map[string]interface{}{"l": "debug", "key1": 1, "key2": "string", "key3": false}
@@ -56,7 +56,7 @@ func BenchmarkLog(b *testing.B) {
 
 func BenchmarkLogComplex(b *testing.B) {
 	//fmt.Println("")
-	l := L.New(os.Stdout, "bench ", L.LstdFlags)
+	l := L.New(os.Stderr, "bench ", L.LstdFlags)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		debug := map[string]interface{}{"l": "debug", "key1": 1, "obj": testObject}
@@ -76,7 +76,7 @@ func BenchmarkLogComplex(b *testing.B) {
 
 func BenchmarkLogxi(b *testing.B) {
 	//fmt.Println("")
-	stdout := log.NewConcurrentWriter(os.Stdout)
+	stdout := log.NewConcurrentWriter(os.Stderr)
 	l := log.NewLogger3(stdout, "bench", log.NewJSONFormatter("bench"))
 	l.SetLevel(log.LevelDebug)
 
@@ -92,7 +92,7 @@ func BenchmarkLogxi(b *testing.B) {
 
 func BenchmarkLogxiComplex(b *testing.B) {
 	//fmt.Println("")
-	stdout := log.NewConcurrentWriter(os.Stdout)
+	stdout := log.NewConcurrentWriter(os.Stderr)
 	l := log.NewLogger3(stdout, "bench", log.NewJSONFormatter("bench"))
 	l.SetLevel(log.LevelDebug)
 
@@ -110,6 +110,7 @@ func BenchmarkLogxiComplex(b *testing.B) {
 func BenchmarkLogrus(b *testing.B) {
 	//fmt.Println("")
 	l := logrus.New()
+	l.Out = os.Stderr
 	l.Formatter = &logrus.JSONFormatter{}
 
 	b.ResetTimer()
@@ -125,6 +126,7 @@ func BenchmarkLogrus(b *testing.B) {
 func BenchmarkLogrusComplex(b *testing.B) {
 	//fmt.Println("")
 	l := logrus.New()
+	l.Out = os.Stderr
 	l.Formatter = &logrus.JSONFormatter{}
 
 	b.ResetTimer()
@@ -140,7 +142,7 @@ func BenchmarkLogrusComplex(b *testing.B) {
 func BenchmarkLog15(b *testing.B) {
 	//fmt.Println("")
 	l := log15.New(log15.Ctx{"_n": "bench", "_p": pid})
-	l.SetHandler(log15.SyncHandler(log15.StreamHandler(os.Stdout, log15.JsonFormat())))
+	l.SetHandler(log15.SyncHandler(log15.StreamHandler(os.Stderr, log15.JsonFormat())))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -156,7 +158,7 @@ func BenchmarkLog15(b *testing.B) {
 func BenchmarkLog15Complex(b *testing.B) {
 	//fmt.Println("")
 	l := log15.New(log15.Ctx{"_n": "bench", "_p": pid})
-	l.SetHandler(log15.SyncHandler(log15.StreamHandler(os.Stdout, log15.JsonFormat())))
+	l.SetHandler(log15.SyncHandler(log15.StreamHandler(os.Stderr, log15.JsonFormat())))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Simple way for see bench test result without grep

```
$ go test -bench=. -benchmem 2>/dev/null
PASS
BenchmarkLog-4                100000         18313 ns/op        4321 B/op        100 allocs/op
BenchmarkLogComplex-4          50000         35466 ns/op        8098 B/op        188 allocs/op
BenchmarkLogxi-4              100000         13660 ns/op        2321 B/op         58 allocs/op
BenchmarkLogxiComplex-4        50000         31842 ns/op        5458 B/op        154 allocs/op
BenchmarkLogrus-4              50000         32836 ns/op        8106 B/op        165 allocs/op
BenchmarkLogrusComplex-4       30000         45276 ns/op       10843 B/op        229 allocs/op
BenchmarkLog15-4               30000         45826 ns/op        7970 B/op        192 allocs/op
BenchmarkLog15Complex-4        20000         68531 ns/op       11206 B/op        242 allocs/op
ok      github.com/mgutz/logxi/v1/bench 15.412s
```
