### PR TITLE
JSONFormatter: check implemented interface before scalars

### DIFF
--- a/v1/jsonFormatter.go
+++ b/v1/jsonFormatter.go
@@ -72,6 +72,29 @@ func (jf *JSONFormatter) appendValue(buf bufferWriter, val interface{}) {
 		value = value.Elem()
 		kind = value.Kind()
 	}
+
+	if stringer, ok := val.(fmt.Stringer); ok {
+		b, err := json.Marshal(stringer.String())
+		if err != nil {
+			// Try other value types first, error handling happens in the
+			// default case below.
+		} else {
+			buf.Write(b)
+			return
+		}
+	}
+
+	if _, ok := val.(json.Marshaler); ok {
+		b, err := json.Marshal(val)
+		if err != nil {
+			// Try other value types first, error handling happens in the
+			// default case below.
+		} else {
+			buf.Write(b)
+			return
+		}
+	}
+
 	switch kind {
 	case reflect.Bool:
 		if value.Bool() {

--- a/v1/jsonFormatter_test.go
+++ b/v1/jsonFormatter_test.go
@@ -1,0 +1,63 @@
+package log
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type myFloatStringer float64
+
+func (f myFloatStringer) String() string {
+	switch f {
+	case myFloatStringer(math.Inf(1)):
+		return "Inf"
+	default:
+		return fmt.Sprint(float64(f))
+	}
+}
+
+func TestLogEntry_CustomScalarStringer(t *testing.T) {
+	assert := assert.New(t)
+
+	jf := NewJSONFormatter("test")
+
+	entry := jf.LogEntry(LevelInfo, "testing myFloat", []interface{}{
+		"f", myFloatStringer(10),
+	})
+	assert.Equal("10", entry["f"])
+
+	entry = jf.LogEntry(LevelInfo, "testing myFloat", []interface{}{
+		"f", myFloatStringer(math.Inf(1)),
+	})
+	assert.Equal("Inf", entry["f"])
+}
+
+type myFloatMarshaler float64
+
+func (f myFloatMarshaler) MarshalJSON() ([]byte, error) {
+	switch f {
+	case myFloatMarshaler(math.Inf(1)):
+		return []byte(`"Inf"`), nil
+	default:
+		return []byte(fmt.Sprint(float64(f))), nil
+	}
+}
+
+func TestLogEntry_CustomScalarMarshaler(t *testing.T) {
+	assert := assert.New(t)
+
+	jf := NewJSONFormatter("test")
+
+	entry := jf.LogEntry(LevelInfo, "testing myFloat", []interface{}{
+		"f", myFloatMarshaler(10),
+	})
+	assert.Equal(float64(10), entry["f"])
+
+	entry = jf.LogEntry(LevelInfo, "testing myFloat", []interface{}{
+		"f", myFloatMarshaler(math.Inf(1)),
+	})
+	assert.Equal("Inf", entry["f"])
+}


### PR DESCRIPTION
A type alias for built-in scalar types may implement the fmt.Stringer or json.Marshaler interface. However, the JSONFormatter checked for the scalar type before considering the interfaces, and then used one of the strconv functions to encode the value. 

That is a) unexpected and b) doesn't necessarily produce correct JSON, leading to a panic. For instance, `strconv.FormatFloat(math.Inf(1), 'g', -1, 64)` encodes to `+Inf`, not `"+Inf"`.